### PR TITLE
Quickfix to near scrolling & fix to default scrolling.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Next
+
+# 0.4.1
+- Quickfix to bug that was created by 0.4, when you scrolled one on the left or right, the scroll would freak out.
+- Fix to default selecting, now it behaves correctly.
+
 # 0.4
 - 🚀Fixed bug when you spinned the carousel while it was spinning. When you did this, the carousel would mess up the destination target and wouldn’t really select the item in the middle, but slightly off.
 

--- a/Examples/Example2/Example2/ViewController.swift
+++ b/Examples/Example2/Example2/ViewController.swift
@@ -29,6 +29,7 @@ class ViewController: UIViewController {
         carouselView = SwiftCarousel(frame: carouselFrame, choices: choices)
         carouselView.resizeType = .WithoutResizing(10.0)
         carouselView.delegate = self
+        carouselView.defaultSelectedIndex = 2
         view.addSubview(carouselView)
         
         let labelFrame = CGRect(x: view.center.x - 150.0, y: CGRectGetMinY(carouselFrame) - 40.0, width: 300.0, height: 20.0)

--- a/Source/SwiftCarousel.swift
+++ b/Source/SwiftCarousel.swift
@@ -280,6 +280,7 @@ public class SwiftCarousel: UIView {
         
         currentSelectedIndex = selectedIndex
         currentRealSelectedIndex = realSelectedIndex
+        currentVelocityX = nil
     }
     
     /**

--- a/Source/SwiftCarousel.swift
+++ b/Source/SwiftCarousel.swift
@@ -58,6 +58,9 @@ public class SwiftCarousel: UIView {
             }
         }
     }
+    /// If there is defaultSelectedIndex and was selected, the variable is true.
+    /// Otherwise it is not.
+    public var didSetDefaultIndex: Bool = false
     /// Current selected index (calculated by searching through views),
     /// It returns index between 0 and originalChoicesNumber.
     public var selectedIndex: Int? {
@@ -216,13 +219,18 @@ public class SwiftCarousel: UIView {
         scrollView.contentSize = CGSize(width: width, height: CGRectGetHeight(frame))
         maxVelocity = scrollView.contentSize.width / 6.0
         
-        // we do not want to change the selected index in case of hiding and
-        // showing view, which also triggers layout
-        guard currentSelectedIndex == nil else {return}
+        // We do not want to change the selected index in case of hiding and
+        // showing view, which also triggers layout.
+        // On the other hand this method can be triggered when the defaultSelectedIndex
+        // was set after the carousel init, so we check if the default index is != nil
+        // and that it wasn't set before.
+        guard currentSelectedIndex == nil ||
+            (didSetDefaultIndex == false && defaultSelectedIndex != nil) else { return }
         
         // Center the view
         if defaultSelectedIndex != nil {
-            selectItem(defaultSelectedIndex!, animated: true)
+            selectItem(defaultSelectedIndex!, animated: false)
+            didSetDefaultIndex = true
         } else {
             selectItem(0, animated: false)
         }

--- a/SwiftCarousel.podspec
+++ b/SwiftCarousel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SwiftCarousel"
-  s.version          = "0.4.0"
+  s.version          = "0.4.1"
   s.summary          = "Infinite carousel of options."
   s.description      = "SwiftCarousel is a fully native Swift UIScrollView wrapper, that allows you to infinite circular scroll with UIView objects."
   s.homepage         = "https://github.com/Sunshinejr/SwiftCarousel"


### PR DESCRIPTION
- Quickfix to bug that was created by 0.4, when you scrolled one on the left or right, the scroll would freak out.
- Fix to default selecting, now it behaves correctly.
