### PR TITLE
Items factory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 - Add `itemsFactory(itemsCount:factory:)` method which can be used instead of items variable to set the carousel views.
 - **Breaking change** Replace convenience init `init(frame:choices:)` to `init(frame:items:)`.
 - Change Example2 to use `itemsFactory(itemsCount:factory:)` instead of `items`.
+- Improve `UIView().copyView()` (it will copy also constraints now for view & subviews).
 
 # 0.4.1
 - Quickfix to bug that was created by 0.4, when you scrolled one on the left or right, the scroll would freak out.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # Next
+- Add `itemsFactory(itemsCount:factory:)` method which can be used instead of items variable to set the carousel views.
+- **Breaking change** Replace convenience init `init(frame:choices:)` to `init(frame:items:)`.
+- Change Example2 to use `itemsFactory(itemsCount:factory:)` instead of `items`.
 
 # 0.4.1
 - Quickfix to bug that was created by 0.4, when you scrolled one on the left or right, the scroll would freak out.

--- a/Examples/Example2/Example2/ViewController.swift
+++ b/Examples/Example2/Example2/ViewController.swift
@@ -21,12 +21,12 @@ class ViewController: UIViewController {
         
         let carouselFrame = CGRect(x: view.center.x - 200.0, y: view.center.y - 100.0, width: 400.0, height: 200.0)
         carouselView = SwiftCarousel(frame: carouselFrame)
-        carouselView.itemsFactory = (itemsCount: 5, factory: { choice in
+        carouselView.itemsFactory(itemsCount: 5) { choice in
             let imageView = UIImageView(image: UIImage(named: "puppy\(choice+1)"))
             imageView.frame = CGRect(origin: CGPointZero, size: CGSize(width: 200.0, height: 200.0))
             
             return imageView
-        })
+        }
         carouselView.resizeType = .WithoutResizing(10.0)
         carouselView.delegate = self
         carouselView.defaultSelectedIndex = 2

--- a/Examples/Example2/Example2/ViewController.swift
+++ b/Examples/Example2/Example2/ViewController.swift
@@ -20,13 +20,13 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view, typically from a nib.
         
         let carouselFrame = CGRect(x: view.center.x - 200.0, y: view.center.y - 100.0, width: 400.0, height: 200.0)
-        choices = (1...5).map { choice in
-            let imageView = UIImageView(image: UIImage(named: "puppy\(choice)"))
+        carouselView = SwiftCarousel(frame: carouselFrame)
+        carouselView.itemsFactory = (itemsCount: 5, factory: { choice in
+            let imageView = UIImageView(image: UIImage(named: "puppy\(choice+1)"))
             imageView.frame = CGRect(origin: CGPointZero, size: CGSize(width: 200.0, height: 200.0))
             
             return imageView
-        }
-        carouselView = SwiftCarousel(frame: carouselFrame, choices: choices)
+        })
         carouselView.resizeType = .WithoutResizing(10.0)
         carouselView.delegate = self
         carouselView.defaultSelectedIndex = 2

--- a/Source/SwiftCarousel.swift
+++ b/Source/SwiftCarousel.swift
@@ -112,24 +112,22 @@ public class SwiftCarousel: UIView {
     /// and you need to specify closure that will create that view. Remember that it should
     /// always create new view, not give the same reference all the time.
     /// You can always setup your carousel using `items` instead.
-    public var itemsFactory: (itemsCount: Int, factory: (index: Int) -> UIView)? {
-        didSet {
-            guard let factory = itemsFactory?.factory, count = itemsFactory?.itemsCount where count > 0 else { return }
-            
-            originalChoicesNumber = count
-            (0..<3).forEach { counter in
-                let newViews: [UIView] = 0.stride(to: count, by: 1).map { i in
-                    var view = factory(index: i)
-                    if self.choices.contains(view) {
-                        view = view.copyView()
-                    }
-                    
-                    return view
+    public func itemsFactory(itemsCount count: Int, factory: (index: Int) -> UIView) {
+        guard count > 0 else { return }
+        
+        originalChoicesNumber = count
+        (0..<3).forEach { counter in
+            let newViews: [UIView] = 0.stride(to: count, by: 1).map { i in
+                var view = factory(index: i)
+                if self.choices.contains(view) {
+                    view = view.copyView()
                 }
-                self.choices.appendContentsOf(newViews)
+                
+                return view
             }
-            setupViews(choices)
+            self.choices.appendContentsOf(newViews)
         }
+        setupViews(choices)
     }
     
     // MARK: - Inits

--- a/Source/SwiftCarousel.swift
+++ b/Source/SwiftCarousel.swift
@@ -99,7 +99,11 @@ public class SwiftCarousel: UIView {
                     if counter == 1 {
                         return choice
                     } else {
-                        return choice.copyView()
+                        do {
+                            return try choice.copyView()
+                        } catch {
+                            fatalError("There was a problem with copying view.")
+                        }
                     }
                 }
                 self.choices.appendContentsOf(newViews)
@@ -120,7 +124,11 @@ public class SwiftCarousel: UIView {
             let newViews: [UIView] = 0.stride(to: count, by: 1).map { i in
                 var view = factory(index: i)
                 if self.choices.contains(view) {
-                    view = view.copyView()
+                    do {
+                        view = try view.copyView()
+                    } catch {
+                        fatalError("There was a problem with copying view.")
+                    }
                 }
                 
                 return view

--- a/Source/SwiftCarousel.swift
+++ b/Source/SwiftCarousel.swift
@@ -150,10 +150,10 @@ public class SwiftCarousel: UIView {
      - parameter choices: Items to put in carousel.
      
      */
-    public convenience init(frame: CGRect, choices: [UIView]) {
+    public convenience init(frame: CGRect, items: [UIView]) {
         self.init(frame: frame)
         setup()
-        items = choices
+        self.items = items
     }
     
     deinit {

--- a/Source/SwiftCarousel.swift
+++ b/Source/SwiftCarousel.swift
@@ -85,7 +85,8 @@ public class SwiftCarousel: UIView {
         
         return index
     }
-    /// Returns carousel views.
+    /// Carousel items. You can setup your carousel using this method (static items), or
+    /// you can also see `itemsFactory`, which uses closure for the setup.
     public var items: [UIView] {
         get {
             return [UIView](choices[choices.count / 3..<(choices.count / 3 + originalChoicesNumber)])
@@ -100,6 +101,30 @@ public class SwiftCarousel: UIView {
                     } else {
                         return choice.copyView()
                     }
+                }
+                self.choices.appendContentsOf(newViews)
+            }
+            setupViews(choices)
+        }
+    }
+    
+    /// Factory for carousel items. Here you specify how many items do you want in carousel
+    /// and you need to specify closure that will create that view. Remember that it should
+    /// always create new view, not give the same reference all the time.
+    /// You can always setup your carousel using `items` instead.
+    public var itemsFactory: (itemsCount: Int, factory: (index: Int) -> UIView)? {
+        didSet {
+            guard let factory = itemsFactory?.factory, count = itemsFactory?.itemsCount where count > 0 else { return }
+            
+            originalChoicesNumber = count
+            (0..<3).forEach { counter in
+                let newViews: [UIView] = 0.stride(to: count, by: 1).map { i in
+                    var view = factory(index: i)
+                    if self.choices.contains(view) {
+                        view = view.copyView()
+                    }
+                    
+                    return view
                 }
                 self.choices.appendContentsOf(newViews)
             }

--- a/Source/UIView+SwiftCarousel.swift
+++ b/Source/UIView+SwiftCarousel.swift
@@ -20,15 +20,24 @@
 * THE SOFTWARE.
 */
 
-extension UIView {
+public enum ArchiveCopyingError: ErrorType {
+    case View
+}
+
+public extension UIView {
+    private func prepareConstraintsForArchiving() {
+        constraints.forEach { $0.shouldBeArchived = true }
+        subviews.forEach { $0.prepareConstraintsForArchiving() }
+    }
+    
     /**
      Method to copy UIView using archivizing.
      
      - returns: Copied UIView (different memory address than current)
      */
-    func copyView() -> UIView {
-        let serialized = NSKeyedArchiver.archivedDataWithRootObject(self)
-        
-        return NSKeyedUnarchiver.unarchiveObjectWithData(serialized) as! UIView
+    public func copyView() throws -> UIView {
+        prepareConstraintsForArchiving()
+        guard let view = NSKeyedUnarchiver.unarchiveObjectWithData(NSKeyedArchiver.archivedDataWithRootObject(self)) as? UIView else { throw ArchiveCopyingError.View }
+        return view
     }
 }


### PR DESCRIPTION
Hey guys! 🎉 So I had some time and tried to repair #11 with improving copying method and adding new method that takes closure and `itemsCount` as parameters instead of static views. I'd love if you could check this out @aocenas and @irodrigo17 to check if everything is now clear on your part. You can use development pod or:

```
pod 'SwiftCarousel', :head
```

Thanks! Log from the PR:
- [x]  Add `itemsFactory(itemsCount:factory:)` method which can be used instead of items variable to set the carousel views.
- [x]  **Breaking change** Replace convenience init `init(frame:choices:)` to `init(frame:items:)`.
- [x] Change Example2 to use `itemsFactory(itemsCount:factory:)` instead of `items`.
- [x] Improve `UIView().copyView()` (it will copy also constraints now for view & subviews). Thanks to @afilipowicz.
